### PR TITLE
Bugfix: error in units for Poisson ratio

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,9 @@
 =======
 History
 =======
+2025.9.6 -- Bugfix: error in units for Poisson ratio
+    * Corrected the metadata to indicate that the Poisson ratio has no units.
+
 2025.9.4 -- Bugfixes: numerical issues and missing item in the GUI
     * Fixed numerical overflows that occurred for larger Debye temperature, > ~700 K
     * The list of temperatures for the thermochemistry functions was missing in the GUI.

--- a/thermomechanical_step/metadata.py
+++ b/thermomechanical_step/metadata.py
@@ -215,7 +215,7 @@ metadata["results"] = {
         "description": "Voigt Poisson ratio",
         "dimensionality": "scalar",
         "type": "float",
-        "units": "GPa",
+        "units": "",
     },
     "Kr": {
         "description": "Reuss bulk modulus",
@@ -239,7 +239,7 @@ metadata["results"] = {
         "description": "Reuss Poisson ratio",
         "dimensionality": "scalar",
         "type": "float",
-        "units": "GPa",
+        "units": "",
     },
     "Kh": {
         "description": "Hill bulk modulus",
@@ -267,7 +267,7 @@ metadata["results"] = {
         "dimensionality": "scalar",
         "property": "Poisson ratio#Thermomechanical#{model}",
         "type": "float",
-        "units": "GPa",
+        "units": "",
     },
     "vt": {
         "description": "transverse sound velocity",


### PR DESCRIPTION
    
* Corrected the metadata to indicate that the Poisson ratio has no units.